### PR TITLE
Rotate treads in cockpit view bool

### DIFF
--- a/Ini/GP4PP.ini
+++ b/Ini/GP4PP.ini
@@ -1,7 +1,7 @@
 [Settings]
 DisableCDCheck = false
 Fix3DWheels = false
-RotateTreadsInCockpitView = false
+Fix3DWheelsCockpitView = false
 TrackFolders = false
 CockpitVisor = false
 StWheelAdvancedCarShader = false

--- a/Ini/GP4PP.ini
+++ b/Ini/GP4PP.ini
@@ -1,6 +1,7 @@
 [Settings]
 DisableCDCheck = false
 Fix3DWheels = false
+RotateTreadsInCockpitView = false
 TrackFolders = false
 CockpitVisor = false
 StWheelAdvancedCarShader = false

--- a/Patches/General.cpp
+++ b/Patches/General.cpp
@@ -10,7 +10,7 @@ namespace General
 	//General settings variables
 	bool disableCDCheck = false;
 	bool fix3DWheelsTreadMapping = false;
-	bool rotateInCockpitView = false;
+	bool fix3DWheelsCockpitView = false;
 	bool stWheelAdvancedCarShader = false;
 
 	//Target Addresses
@@ -70,12 +70,12 @@ namespace General
 		initD3DMatrixVariables();
 
 		//invert the Y axis for the tyre tread texture on the left wheels
-		if (collisionMeshIndex == 0x12 || collisionMeshIndex == 0x16)
+		if (fix3DWheelsTreadMapping && (collisionMeshIndex == 0x12 || collisionMeshIndex == 0x16))
 		{
 			(*d3dMatrix_0xc0)[1][1] = -1;
 		}
 		//rotate the tyre tread texture when in cockpit view
-		if (rotateInCockpitView && ptrMeshContainer == GP4MemLib::MemUtils::addressToValue<DWORD>(ptrCockpitWheels))
+		if (fix3DWheelsCockpitView && ptrMeshContainer == GP4MemLib::MemUtils::addressToValue<DWORD>(ptrCockpitWheels))
 		{
 			(*d3dMatrix_0xc0)[0][0] = -1;
 			(*d3dMatrix_0xc0)[1][1] = -(*d3dMatrix_0xc0)[1][1];
@@ -119,11 +119,11 @@ namespace General
 		// Rotate cockpit view for front wheels (1 = enabled, 0 = disabled)
 		try
 		{
-			rotateInCockpitView = iniSettings["Settings"]["RotateTreadsInCockpitView"].getAs<bool>();
+			fix3DWheelsCockpitView = iniSettings["Settings"]["Fix3DWheelsCockpitView"].getAs<bool>();
 		}
 		catch (exception ex) {}
 
-		OutputGP4PPDebugString("Rotate Treads in Cockpit View : " + string(rotateInCockpitView ? "Enabled" : "Disabled"));
+		OutputGP4PPDebugString("Rotate Treads in Cockpit View : " + string(fix3DWheelsCockpitView ? "Enabled" : "Disabled"));
 
 		// Enable Advanced Car Shader for in-cockpit steering wheel
 		try
@@ -146,7 +146,7 @@ namespace General
 		}
 
 		// Apply Fix 3D Wheels Tread Mapping Patch
-		if (fix3DWheelsTreadMapping)
+		if (fix3DWheelsTreadMapping || fix3DWheelsCockpitView)
 		{
 			//Re-route for wheel tread texture set matrix
 			MemUtils::rerouteFunction(wheelShaderSetMatrixStartAddress, PtrToUlong(wheelShaderSetMatrixFunc), VAR_NAME(wheelShaderSetMatrixFunc));

--- a/Patches/General.cpp
+++ b/Patches/General.cpp
@@ -10,6 +10,7 @@ namespace General
 	//General settings variables
 	bool disableCDCheck = false;
 	bool fix3DWheelsTreadMapping = false;
+	bool rotateInCockpitView = false;
 	bool stWheelAdvancedCarShader = false;
 
 	//Target Addresses
@@ -74,7 +75,7 @@ namespace General
 			(*d3dMatrix_0xc0)[1][1] = -1;
 		}
 		//rotate the tyre tread texture when in cockpit view
-		if (ptrMeshContainer == GP4MemLib::MemUtils::addressToValue<DWORD>(ptrCockpitWheels))
+		if (rotateInCockpitView && ptrMeshContainer == GP4MemLib::MemUtils::addressToValue<DWORD>(ptrCockpitWheels))
 		{
 			(*d3dMatrix_0xc0)[0][0] = -1;
 			(*d3dMatrix_0xc0)[1][1] = -(*d3dMatrix_0xc0)[1][1];
@@ -114,6 +115,15 @@ namespace General
 		catch (exception ex) {}
 
 		OutputGP4PPDebugString("Fix 3D Wheels Tread Mapping : " + string(fix3DWheelsTreadMapping ? "Enabled" : "Disabled"));
+
+		// Rotate cockpit view for front wheels (1 = enabled, 0 = disabled)
+		try
+		{
+			rotateInCockpitView = iniSettings["Settings"]["RotateTreadsInCockpitView"].getAs<bool>();
+		}
+		catch (exception ex) {}
+
+		OutputGP4PPDebugString("Rotate Treads in Cockpit View : " + string(rotateInCockpitView ? "Enabled" : "Disabled"));
 
 		// Enable Advanced Car Shader for in-cockpit steering wheel
 		try


### PR DESCRIPTION
When using 2001 Tyres & Rims set for GP4 by Hega ([link](https://www.grandprixgames.org/read.php?4,1139921,page=1)) the cockpit front wheel treads are mirrored or rotated. Created the option in the General settings in the GP4PP.ini (RotateTreadsInCockpitView =) to disable this rotation or mirror so the textures or treads match the correct pattern.